### PR TITLE
Add the `Get Label Pages` endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Create a **Confluence Cloud API** credential with:
 | **Update Page** | `PUT /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-put) |
 | **Delete Page** | `DELETE /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-delete) |
 | **Get Pages In Space** | `GET /spaces/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-pages-get) |
-| **Get Label Pages** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
+| **Get Pages For Label** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
 
 ### 📄 **Template Operations**
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ Create a **Confluence Cloud API** credential with:
 
 | Operation | Method | API Version | Documentation |
 |-----------|--------|-------------|---------------|
+| **Get Attachment Labels** | `GET /attachments/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--attachments-id-labels-get) |
+| **Get Blog Post Labels** | `GET /blogposts/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--blogposts-id-labels-get) |
+| **Get Custom Content Labels** | `GET /custom-content/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--custom-content-id-labels-get) |
 | **Get Labels** | `GET /labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--labels-get) |
-
-
+| **Get Page Labels** | `GET /pages/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-labels-get) |
+| **Get Space Labels** | `GET /spaces/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-labels-get) |
+| **Get Space Content Labels** | `GET /spaces/{id}/content/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--spaces-id-content-labels-get) |
 
 ## 💡 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Create a **Confluence Cloud API** credential with:
 | **Delete Inline Comment** | `DELETE /inline-comments/{comment-id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--inline-comments-comment-id-delete) |
 | **Get Inline Comment Children** | `GET /inline-comments/{id}/children` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--inline-comments-id-children-get) |
 
+### 📄 **Label Operations**
+
+| Operation | Method | API Version | Documentation |
+|-----------|--------|-------------|---------------|
+| **Get Labels** | `GET /labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--labels-get) |
+
 
 
 ## 💡 Usage Examples

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Create a **Confluence Cloud API** credential with:
 | **Update Page** | `PUT /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-put) |
 | **Delete Page** | `DELETE /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-delete) |
 | **Get Pages In Space** | `GET /spaces/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-pages-get) |
-| **Get Pages For Label** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
+| **Get Label Pages** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
 
 ### 📄 **Template Operations**
 
@@ -126,7 +126,10 @@ Create a **Confluence Cloud API** credential with:
 | **Get Labels** | `GET /labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--labels-get) |
 | **Get Page Labels** | `GET /pages/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-labels-get) |
 | **Get Space Labels** | `GET /spaces/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-labels-get) |
-| **Get Space Content Labels** | `GET /spaces/{id}/content/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--spaces-id-content-labels-get) |
+| **Get Space Content Labels** | `GET /spaces/{id}/content/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-content-labels-get) |
+| **Get Page Labels** | `GET /pages/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-labels-get) |
+
+
 
 ## 💡 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Create a **Confluence Cloud API** credential with:
 | **Update Page** | `PUT /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-put) |
 | **Delete Page** | `DELETE /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-delete) |
 | **Get Pages In Space** | `GET /spaces/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-pages-get) |
+| **Get Label Pages** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
 
 ### 📄 **Template Operations**
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Create a **Confluence Cloud API** credential with:
 | **Update Page** | `PUT /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-put) |
 | **Delete Page** | `DELETE /pages/{id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-delete) |
 | **Get Pages In Space** | `GET /spaces/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-pages-get) |
-| **Get Pages For Label** | `GET /labels/{id}/pages` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--labels-id-pages-get) |
 
 ### 📄 **Template Operations**
 
@@ -116,17 +115,7 @@ Create a **Confluence Cloud API** credential with:
 | **Delete Inline Comment** | `DELETE /inline-comments/{comment-id}` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--inline-comments-comment-id-delete) |
 | **Get Inline Comment Children** | `GET /inline-comments/{id}/children` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--inline-comments-id-children-get) |
 
-### 📄 **Label Operations**
 
-| Operation | Method | API Version | Documentation |
-|-----------|--------|-------------|---------------|
-| **Get Attachment Labels** | `GET /attachments/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--attachments-id-labels-get) |
-| **Get Blog Post Labels** | `GET /blogposts/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--blogposts-id-labels-get) |
-| **Get Custom Content Labels** | `GET /custom-content/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--custom-content-id-labels-get) |
-| **Get Labels** | `GET /labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--labels-get) |
-| **Get Page Labels** | `GET /pages/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api--pages-id-labels-get) |
-| **Get Space Labels** | `GET /spaces/{id}/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api--spaces-id-labels-get) |
-| **Get Space Content Labels** | `GET /spaces/{id}/content/labels` | V2 | [📖 V2 API Docs](https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#api--spaces-id-content-labels-get) |
 
 ## 💡 Usage Examples
 

--- a/config/confluence-routes.json
+++ b/config/confluence-routes.json
@@ -142,6 +142,16 @@
           "methods": ["get"]
         }
       ]
+    },
+    "label": {
+      "displayName": "Label",
+      "description": "Work with Confluence labels",
+      "routes": [
+        {
+          "path": "/labels",
+          "methods": ["get"]
+        }
+      ]
     }
   }
 }

--- a/config/confluence-routes.json
+++ b/config/confluence-routes.json
@@ -148,9 +148,38 @@
       "description": "Work with Confluence labels",
       "routes": [
         {
+          "path": "/attachments/{id}/labels",
+          "methods": ["get"]
+        },
+        {
+          "path": "/blogposts/{id}/labels",
+          "methods": ["get"]
+        },
+        {
+          "path": "/custom-content/{id}/labels",
+          "methods": ["get"]
+        },
+        {
           "path": "/labels",
           "methods": ["get"]
+        },
+        {
+          "path": "/pages/{id}/labels",
+          "methods": ["get"]
+        },
+        {
+          "path": "/spaces/{id}/labels",
+          "methods": ["get"]
+        },
+        {
+          "path": "/spaces/{id}/content/labels",
+          "methods": ["get"]
+        },
+        {
+          "path": "/pages/{id}/labels",
+          "methods": ["get"]
         }
+
       ]
     }
   }

--- a/config/confluence-routes.json
+++ b/config/confluence-routes.json
@@ -49,6 +49,10 @@
         {
           "path": "/spaces/{id}/pages",
           "methods": ["get"]
+        },
+        {
+          "path": "/labels/{id}/pages",
+          "methods": ["get"]
         }
       ]
     },


### PR DESCRIPTION
Thanks for this plugin! I have many many pages in my many spaces though so getting _all pages_ and then post-filtering isn't always feasible. ~This adds the V2 API endpoint to get pages by a label.~ (edit) This adds `Get pages for label` _plus_ all of the [`Get label *` endpoints](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-label/#api-group-label).